### PR TITLE
feat: add `ext-json` extension to `composer.json` 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
   "require": {
+    "ext-json": "*",
     "nikic/php-parser": "5.0.0"
   }
 }


### PR DESCRIPTION
Explicitly declared `ext-json` extension in `composer.json` to ensure compatibility with JSON-related functions used in the project